### PR TITLE
Document updates

### DIFF
--- a/core/21-045.adoc
+++ b/core/21-045.adoc
@@ -24,7 +24,7 @@
 |Internal reference number of this OGC(R) document:    21-045
 |Version: {m_n} (Editor's Draft)
 |Category: OGC(R) Implementation Standard
-|Editor:   <Name(s) of Editor or Editors>
+|Editor:   Clemens Portele, Panagiotis (Peter) A. Vretanos, ... 
 |===
 
 [cols = "^", frame = "none"]

--- a/core/annex-b.adoc
+++ b/core/annex-b.adoc
@@ -23,20 +23,20 @@ include::schemas/featurecollection.json[]
 include::schemas/feature.json[]
 ----
 
-[[schema-when]]
-=== JSON schema of the "when" member
+[[schema-time]]
+=== JSON schema of the "time" member
 
 [source,json,linenumbers]
 ----
-include::schemas/when.json[]
+include::schemas/time.json[]
 ----
 
-[[schema-where]]
-=== JSON schema of the "where" member
+[[schema-place]]
+=== JSON schema of the "place" member
 
 [source,json,linenumbers]
 ----
-include::schemas/where.json[]
+include::schemas/place.json[]
 ----
 
 [[schema-coordrefsys]]

--- a/core/annex-bibliography.adoc
+++ b/core/annex-bibliography.adoc
@@ -7,10 +7,12 @@
 
 [[json-schema-validation]] **JSON Schema Validation: A Vocabulary for Structural Validation of JSON**. Edited by A. Wright, H. Andrews, B. Hutton. 2019. Available at https://json-schema.org/draft/2019-09/json-schema-validation.html
 
+[[ogc18_005r4]] Open Geospatial Consortium (OGC). OGC 18-005r4: **OGC Abstract Specification Topic 2: Referencing by coordinates**. Edited by R. Lott. 2019. Available at https://docs.ogc.org/as/18-005r4/18-005r4.html 
+
 [[ogc20_070]] Open Geospatial Consortium (OGC). OGC 20-070: **Geographic information - Features and geometry — Part 2: Metrics**. Edited by J. Herring. 2019. Available at https://portal.ogc.org/files/?artifact_id=94178 (access requires OGC membership)
 
 [[ogc21_018]] Open Geospatial Consortium (OGC). OGC 21-018: **OGC Testbed-17: Features and Geometries JSON CRS Analysis of Alternatives ER**. Edited by P. Vretanos. 2021. Available at https://portal.ogc.org/files/?artifact_id=99382 (access requires OGC membership)
 
 [[sdwbp]] Open Geospatial Consortium (OGC) / World Wide Web Consortium (W3C): **Spatial Data on the Web Best Practices** [online]. Edited by J. Tandy, L. van den Brink, P. Barnaghi. 2017 [viewed 2020-03-16]. Available at https://www.w3.org/TR/sdw-bp/
 
-[[ogc18_005r4]] Open Geospatial Consortium (OGC). OGC 18-005r4: **OGC Abstract Specification Topic 2: Referencing by coordinates**. Edited by R. Lott. 2019. Available at https://docs.ogc.org/as/18-005r4/18-005r4.html 
+[[owl-time]] Open Geospatial Consortium (OGC) / World Wide Web Consortium (W3C). **Time Ontology in OWL** [online]. Edited by S. Cox, C. Little. 2020 [viewed 2020-11-22]. Available at https://www.w3.org/TR/owl-time

--- a/core/annex-bibliography.adoc
+++ b/core/annex-bibliography.adoc
@@ -10,3 +10,7 @@
 [[ogc20_070]] Open Geospatial Consortium (OGC). OGC 20-070: **Geographic information - Features and geometry — Part 2: Metrics**. Edited by J. Herring. 2019. Available at https://portal.ogc.org/files/?artifact_id=94178 (access requires OGC membership)
 
 [[ogc21_018]] Open Geospatial Consortium (OGC). OGC 21-018: **OGC Testbed-17: Features and Geometries JSON CRS Analysis of Alternatives ER**. Edited by P. Vretanos. 2021. Available at https://portal.ogc.org/files/?artifact_id=99382 (access requires OGC membership)
+
+[[sdwbp]] Open Geospatial Consortium (OGC) / World Wide Web Consortium (W3C): **Spatial Data on the Web Best Practices** [online]. Edited by J. Tandy, L. van den Brink, P. Barnaghi. 2017 [viewed 2020-03-16]. Available at https://www.w3.org/TR/sdw-bp/
+
+[[ogc18_005r4]] Open Geospatial Consortium (OGC). OGC 18-005r4: **OGC Abstract Specification Topic 2: Referencing by coordinates**. Edited by R. Lott. 2019. Available at https://docs.ogc.org/as/18-005r4/18-005r4.html 

--- a/core/annex-e.adoc
+++ b/core/annex-e.adoc
@@ -7,11 +7,11 @@
 
 This annex includes considerations for each of the JSON-FG building blocks.
 
-=== Primary temporal geometry ("when")
+=== Primary temporal information ("time")
 
 The following aspects were discussed:
 
-1. The current specification of the "when" member could be extended with minimal extensions beyond the RFC 3339 timestamps to support additional use cases, but this would be left to a future extension:
+1. The current specification of the "time" member could be extended with minimal extensions beyond the RFC 3339 timestamps to support additional use cases, but this would be left to a future extension:
 
   * Supporting instant values of a year (e.g., "1969") or a month (e.g., "1967-07") in addition to dates and timestamps could useful for extents that cover a complete month or year.
   * Supporting instant values of the proleptic Gregorian calendar (i.e., dates before 1582 including negative years) could be useful for historic information.
@@ -23,21 +23,23 @@ The following aspects were discussed:
   * `"2019-10-14/.."`
 
 +
-The main reason for the current design is that this is easier to parse. In a structured language like JSON it is natural to be explicit and use the structures. For example, GeoJSON does not represent the geometry as a WKT string, but as a JSON structure. The JSON encoding of the candidate Common Query Language (CQL2) standard also follows that approach for spatial and temporal geometries.
+The main reason for the current design is that this is easier to parse. In a structured language like JSON it is natural to be explicit and use the structures. For example, GeoJSON does not represent the geometry as a WKT string, but as a JSON structure. The JSON encoding of the candidate Common Query Language (CQL2) standard also follows that approach for spatial and temporal literals.
 
 +
 Another reason for the current design is that an object-based approach can support additional temporal types in the future besides instants and intervals. An example is a time series with an array of timestamps.
 
-3. The current proposal only specifies the use of "when" in the context of a feature. Other contexts could also be supported in the future. For example, a temporal extent for each geometry in a geometry collection, for properties where the value changes over time or a summary information in the feature collection.
+3. The current proposal only specifies the use of "time" in the context of a feature. Other contexts could also be supported in the future. For example, temporal information for each geometry in a geometry collection, for properties where the value changes over time or a summary information in the feature collection.
 
 4. https://stacspec.org[SpatioTemporal Asset Catalog (STAC)] specifies a property https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md#datetime[datetime] that is included in the "properties" member. This approach was not followed for two reasons:
 
-  * Like the feature identifier and the default spatial geometry of a feature, the default temporal extent of a feature should be a "first-class" citizen in the JSON encoding of the feature.
+  * Like the feature identifier and the primary geometry of a feature, the primary temporal information of a feature should be a "first-class" citizen in the JSON encoding of the feature.
   * The use of reserved property names might conflict with existing features that include a "datetime" property with a different specification.
 
-5. Currently there is no information about the semantics of the temporal extent. Is it a temporal extent of a feature that is a version of a real-world entity and there are potential predecessor/successors features of the same entity? Or, in case of a bitemporal dataset, is it the valid time or the transaction/record time? Etc. One potential approach could be the use of a JSON-LD context to associate the "when" member with a property definition in a vocabulary. It was decided to keep the JSON-FG core simple and leave support for more complex requirements to extensions. Support for versioned feature data is one of the planned future work items of the Features API SWG.
+5. Currently there is no information about the semantics of the temporal information. Is it the validity in time of a feature that is a version of a real-world entity and there are potential predecessor/successors features of the same entity? Or, in case of a bitemporal dataset, is it the valid time or the transaction/record time? Etc. One potential approach could be the use of a JSON-LD context to associate the "time" member with a property definition in a vocabulary. It was decided to keep the JSON-FG core simple and leave support for more complex requirements to extensions. Support for versioned feature data is one of the planned future work items of the Features API SWG.
 
-=== Primary spatial geometry ("where", "coordRefSys", "geometry")
+6. There is an existing initiative for a https://github.com/kgeographer/geojson-t[temporal GeoJSON extension ("GeoJSON-T")]. The GeoJSON-T design supports more complex use cases that go beyond the scope of the proposal. To avoid confusion, the SWG is using a different key ("time").
+
+=== Primary geometry ("place", "coordRefSys", "geometry")
 
 The following aspects were discussed:
 

--- a/core/clause_0_front_material.adoc
+++ b/core/clause_0_front_material.adoc
@@ -31,5 +31,7 @@ All questions regarding this submission should be directed to the editor or the 
 
 |===
 |*Name* |*Affiliation*
-| |
+|Clemens Portele _(editor)_ |interactive instruments GmbH
+|Panagiotis (Peter) A. Vretanos _(editor)_ |CubeWerx Inc.
+|... |...
 |===

--- a/core/clause_10_feature_types_and_schemas.adoc
+++ b/core/clause_10_feature_types_and_schemas.adoc
@@ -11,7 +11,7 @@ The Requirements Class "Feature Types and Schemas" adds provisions for feature t
 |Dependency |<<rc_core>>
 |===
 
-=== Identifying the feature type(s)
+=== Feature type(s)
 
 :req: feature-type
 [#{req-class}_{req}]
@@ -55,7 +55,7 @@ The Requirements Class "Feature Types and Schemas" adds provisions for feature t
 ^|A |The "links" array in any JSON-FG feature in the JSON document SHOULD include at least one link object where the "rel" member is set to "type".
 |===
 
-=== Identifying the schema(s)
+=== Schema(s)
 
 :req: schema-link-jsonfg
 [#{req-class}_{req}]

--- a/core/clause_11_media_types.adoc
+++ b/core/clause_11_media_types.adoc
@@ -19,10 +19,10 @@ Required parameters: n/a
 Optional parameters:
 
   "compatibility": If provided, the value "geojson" indicates that JSON-FG features 
-  with a "where" member that is not 'null' will also include a GeoJSON geometry 
+  with a "place" member that is not 'null' will also include a GeoJSON geometry 
   in the "geometry" member (a point, line string, polygon or an aggregation of them 
   in WGS 84). If the parameter is missing, the "geometry" member of a JSON-FG feature 
-  will be 'null', if the "where" member is not 'null'. For any other parameter value, 
+  will be 'null', if the "place" member is not 'null'. For any other parameter value, 
   the behavior is unspecified.
 
 Encoding considerations: binary

--- a/core/clause_1_scope.adoc
+++ b/core/clause_1_scope.adoc
@@ -7,7 +7,7 @@ This Standard specifies the following minimal extensions to the GeoJSON Standard
 * The ability to use Coordinate Reference Systems (CRSs) other than WGS 84;
 * Allow the use of non-Euclidean metrics, in particular ellipsoidal metrics;
 * Solids and multi-solids as geometry types;
-* The ability to encode the primary temporal geometry of a feature; and
+* The ability to encode temporal characteristics of a feature; and
 * The ability to declare the type and the schema of a feature.
 
 Information that can be represented as GeoJSON is encoded as GeoJSON. Additional information is mainly encoded in additional members of the GeoJSON objects. The members use keys that do not conflict with GeoJSON so that GeoJSON clients will be able to parse and understand all aspects that are specified by GeoJSON; JSON-FG clients will also parse and understand the additional capabilities.

--- a/core/clause_2_conformance.adoc
+++ b/core/clause_2_conformance.adoc
@@ -3,7 +3,7 @@ This Standard defines three requirements classes. The standardization target for
 
 The requirements classes are:
 
-* "Core": Support for <<when>>, <<where>> and <<ref-sys>>, except support for <<Polyhedron>> and <<MultiPolyhedron>>. Depends on GeoJSON.
+* "Core": Support for <<time>>, <<place>> and <<ref-sys>>, except support for <<Polyhedron>> and <<MultiPolyhedron>>. Depends on GeoJSON.
 * "3D": Geometries are in a 3D CRS and may be a <<Polyhedron>> or <<MultiPolyhedron>>. Depends on "Core".
 * "Feature Types and Schemas": Support for <<feature-types>> and <<schema-ref>>. Depends on "Core".
 

--- a/core/clause_4_terms_and_definitions.adoc
+++ b/core/clause_4_terms_and_definitions.adoc
@@ -43,7 +43,7 @@ NOTE: A feature can be described by multiple properties with a geometry. For exa
 primary temporal information::
 the position or extent in time that best represents the temporal characteristics of a *feature*
 
-NOTE: A feature can be described by multiple properties with temporal information. For example, an event can have a property with an instant or interval when the event occurred or will occur and another property when the event was recorded in the dataset. In GeoJSON and JSON-FG, multiple properties with a temporal value can be encoded in the "properties" member. In those cases, it is the decision of the generator of the JSON-FG document what temporal information is considered "primary" for the expected use of the feature. The primary temporal information can also be built from two two properties, e.g., when the feature has two properties describing the begin and end instant of an interval.
+NOTE: A feature can be described by multiple properties with temporal information. For example, an event can have a property with an instant or interval when the event occurred or will occur and another property when the event was recorded in the dataset. In GeoJSON and JSON-FG, multiple properties with a temporal value can be encoded in the "properties" member. In those cases, it is the decision of the generator of the JSON-FG document what temporal information is considered "primary" for the expected use of the feature. The primary temporal information can also be built from two properties, e.g., when the feature has two properties describing the begin and end instant of an interval.
 
 === Abbreviated Terms
 

--- a/core/clause_4_terms_and_definitions.adoc
+++ b/core/clause_4_terms_and_definitions.adoc
@@ -43,7 +43,7 @@ NOTE: A feature can be described by multiple properties with a geometry. For exa
 primary temporal information::
 the position or extent in time that best represents the temporal characteristics of a *feature*
 
-NOTE: A feature can be described by multiple properties with temporal information. For example, an event can have a property with an instant or interval when the event occurred or will occur and another property when the event was recorded in the dataset. In GeoJSON and JSON-FG, multiple properties with a temporal value can be encoded in the "properties" member. In those cases, it is the decision of the generator of the JSON-FG document what temporal information is considered "primary" for the expected use of the feature. The primary temporal information can also be built from two properties, e.g., when the feature has two properties describing the begin and end instant of an interval.
+NOTE: A feature can be described by multiple properties with temporal information. For example, an event can have a property with an instant or interval when the event occurred or will occur and another property when the event was recorded in the dataset. In GeoJSON and JSON-FG, multiple properties with a temporal value can be encoded in the "properties" member. In those cases, it is the decision of the generator of the JSON-FG document what temporal information is considered "primary" for the expected use of the feature. The primary temporal information can also be built from two properties, e.g., when the feature has two properties describing the begin and end instants of an interval.
 
 === Abbreviated Terms
 

--- a/core/clause_4_terms_and_definitions.adoc
+++ b/core/clause_4_terms_and_definitions.adoc
@@ -9,23 +9,41 @@ This document also uses terms defined in the OGC Standard for Modular specificat
 For the purposes of this document, the following additional terms and definitions apply.
 
 coordinate reference system::
-coordinate system that is related to an object by a datum [OGC Topic 2, version 5.0]
+coordinate system that is related to an object by a datum [<<ogc18_005r4,OGC Topic 2>>]
+
+NOTE: More information about coordinate reference systems and common problems when dealing with coordinates may be found in the <<sdwbp,W3C/OGC Spatial Data on the Web Best Practice>> in the section link:https://www.w3.org/TR/2017/NOTE-sdw-bp-20170928/#CRS-background['Coordinate Reference Systems (CRS)'].
 
 feature::
 abstraction of real world phenomena [ISO 19101-1:2014]
 
-NOTE: More details about the term 'feature' may be found in the <<SDWBP,W3C/OGC Spatial Data on the Web Best Practice>> in the section link:https://www.w3.org/TR/sdw-bp/#spatial-things-features-and-geometry['Spatial Things, Features and Geometry'].
+NOTE: More details about the term 'feature' may be found in the <<sdwbp,W3C/OGC Spatial Data on the Web Best Practice>> in the section link:https://www.w3.org/TR/2017/NOTE-sdw-bp-20170928/#spatial-things-features-and-geometry['Spatial Things, Features and Geometry'].
 
 feature collection::
 a set of *features* from a dataset
 
 JSON document::
-an information resource (series of octets) described by the application/json media type [JSON Schema 2019-09]
+an information resource (series of octets) described by the application/json media type [<<json-schema,JSON Schema 2019-09>>]
 
 NOTE: The terms "JSON document", "JSON text", and "JSON value" are interchangeable.
 
 JSON-FG document::
 a **JSON document** that conforms to the Requirements Class "Core" of OGC Features and Geometries JSON - Part 1: Core
+
+<JSON> key::
+the name of a *member*
+
+<JSON> member::
+a name/value pair in a JSON object
+
+primary geometry::
+the geometry that best represents the spatial characteristics of a *feature*
+
+NOTE: A feature can be described by multiple properties with a geometry. For example, a radio tower can have a property with a point value that describes the location of the tower and another property with a multi-polygon value that describes the transmission area. In GeoJSON and JSON-FG, multiple properties with a geometry value can be encoded in the "properties" member. In those cases, it is the decision of the generator of the JSON-FG document what geometry is considered "primary" for the expected use of the feature.
+
+primary temporal information::
+the position or extent in time that best represents the temporal characteristics of a *feature*
+
+NOTE: A feature can be described by multiple properties with temporal information. For example, an event can have a property with an instant or interval when the event occurred or will occur and another property when the event was recorded in the dataset. In GeoJSON and JSON-FG, multiple properties with a temporal value can be encoded in the "properties" member. In those cases, it is the decision of the generator of the JSON-FG document what temporal information is considered "primary" for the expected use of the feature. The primary temporal information can also be built from two two properties, e.g., when the feature has two properties describing the begin and end instant of an interval.
 
 === Abbreviated Terms
 
@@ -42,3 +60,5 @@ JSON-LD:: JSON for Linking Data
 OGC:: Open Geospatial Consortium
 
 SWG:: Standards Working Group
+
+WGS 84:: World Geodetic System 1984 

--- a/core/clause_5_conventions.adoc
+++ b/core/clause_5_conventions.adoc
@@ -9,7 +9,7 @@ All requirements and conformance tests that appear in this document are denoted 
 
 === Use of JSON Schema
 
-JSON Schema is used to formally specify the JSON-FG syntax, where possible. Additional requirements are only used where it is not possible to express the requirement in JSON Schema or where this would result in a schema that is considered as too complex. All schemas are in Annex <<schemas>>.
+JSON Schema is used to formally specify the JSON-FG syntax, where possible. Additional requirements are only used where it is not possible to express the requirement in JSON Schema or where this would result in a schema that is considered as too complex. All schemas are in Annex '<<schemas>>'.
 
 === Extensibility
 

--- a/core/clause_6_introduction.adoc
+++ b/core/clause_6_introduction.adoc
@@ -6,7 +6,7 @@ JavaScript Object Notation (JSON) is a popular encoding format for geospatial da
 
 * WGS 84 is the only coordinate reference system that is supported;
 * Geometries are restricted to points, curves and surfaces with linear interpolation; and
-* No general capability is available to specify the schema of a feature, its type or its temporal extent.
+* No general capability is available to specify the schema of a feature, its type or its temporal characteristics.
 
 === Scenarios
 
@@ -29,6 +29,6 @@ In the second scenario (file access), the client has no access to a media type a
 
 The client supports GeoJSON and JSON-FG.
 
-In the first scenario (API access), the client will typically request the JSON-FG representation of the feature using an HTTP header like `Accept: application/vnd.ogc.fg+json, application/geo+json;q=0.8` and a `crs=http://www.opengis.net/def/crs/EPSG/0/5555` query parameter. The header states that the client prefers JSON-FG, but will also accept GeoJSON, if JSON-FG is not available. The response will include the headers `Content-Type: application/vnd.ogc.fg+json` as well as `Content-Crs: \http://www.opengis.net/def/crs/EPSG/0/5555` and include the JSON-FG building blocks including the spatial geometry in the requested projected CRS and the temporal extent.
+In the first scenario (API access), the client will typically request the JSON-FG representation of the feature using an HTTP header like `Accept: application/vnd.ogc.fg+json, application/geo+json;q=0.8` and a `crs=http://www.opengis.net/def/crs/EPSG/0/5555` query parameter. The header states that the client prefers JSON-FG, but will also accept GeoJSON, if JSON-FG is not available. The response will include the headers `Content-Type: application/vnd.ogc.fg+json` as well as `Content-Crs: \http://www.opengis.net/def/crs/EPSG/0/5555` and include the JSON-FG building blocks including the geometry in the requested projected CRS and temporal information.
 
-In the second scenario (file access), the client is in the same position as the GeoJSON client - it has no access to a media type and has to inspect the file to determine - if the file is a GeoJSON, JSON-FG or some other kind of document that it does not understand. JSON-FG documents include explicit declarations that conform to both GeoJSON and JSON-FG. Therefore, the client can identify the document as a JSON-FG document and process the content. Since the JSON-FG document identifies the spatial and temporal extent of each feature, the scene extent and, for example, a time slider can be provided by the client so that the user can filter the features to display in the scene.
+In the second scenario (file access), the client is in the same position as the GeoJSON client - it has no access to a media type and has to inspect the file to determine - if the file is a GeoJSON, JSON-FG or some other kind of document that it does not understand. JSON-FG documents include explicit declarations that conform to both GeoJSON and JSON-FG. Therefore, the client can identify the document as a JSON-FG document and process the content. Since the JSON-FG document provides spatial and temporal information about each feature, the client can zoom in on the features and, for example, provide a time slider so that the user can filter the features that are displayed.

--- a/core/clause_7_building_blocks.adoc
+++ b/core/clause_7_building_blocks.adoc
@@ -38,7 +38,7 @@ More complex cases and other temporal coordinate reference systems are out-of-sc
 
 Features can have temporal properties. These will typically be included in the "properties" member.
 
-* In many datasets all temporal properties are instants (a date or a timestamp) and intervals will be described using two temporal instants, one for the start and one for the end.
+* In many datasets all temporal properties are instants (represented by a date or a timestamp) and intervals will be described using two temporal instants, one for the start and one for the end.
 * Multiple temporal properties are sometimes used to describe different temporal characteristics of a feature. For example, the time instant or interval when the information in the feature is valid (sometimes called "valid time") and the time when the feature was recorded in the dataset (sometimes called "transaction time"). Another example is the https://www.ogc.org/standards/om[Observations & Measurements standard], where an observation has multiple temporal properties including "phenomenon time", "result time" and "valid time".
 
 Like GeoJSON, JSON-FG does not place constraints on the information in the "properties" member. JSON-FG specifies a new JSON member in a feature object (key: "time"). The member describes temporal information (an instant or an interval) that can be used by clients without a need to inspect the "properties" member or to understand the schema of the feature. Clients that are familiar with a dataset can, of course, inspect the information in the "properties" member instead of inspecting the "time" member.
@@ -51,7 +51,8 @@ The value of "whtimeen" is either `null` (no temporal information) or an object.
 [cols="20,10a,70a",options="header"]
 !===
 |Property |Type |Description
-|instant |string |A timestamp or a date. See below for more details about instants.
+|date |string |An instant with a granularity of a date. See below for more details about instants.
+|timestamp |string |An instant with the granularity of a timestamp. See below for more details about instants.
 |interval |[ string ] |An interval, described by an array of the two instants (start and end). See below for more details about intervals.
 !===
 
@@ -68,16 +69,20 @@ An instant is a value that conforms to https://datatracker.ietf.org/doc/html/rfc
 * `full-date` (e.g., `"1969-07-20"`)
 * `date-time` (e.g., `"1969-07-20T20:17:40Z"`)
 
-Note that all timestamps have to include a time zone. The use of UTC is recommended ("Z").
+Conceptually, an instant is a "temporal entity with zero extent or duration" [<<owl-time,Time Ontology in OWL>>]. In practice, the temporal position of an instant is described using data types where each value has some duration or granularity. The value should be described with a granularity that is sufficient for the intended use of the data.
 
-NOTE: #GeoPackage, the next versions of CDB and the Common Query Language will only support UTC as a time zone in literal values. Should JSON-FG follow this approach?#
+In the case of a timestamp the granularity is a second or smaller. All timestamps have to be in the time zone UTC ("Z").
+
+In the case of a date the granularity is a day and dates as instants will be used when a granularity of a day independent of its timezone is sufficient for the intended use of the data. If that is not the case and, for example, the timezone is important for the intended use, the temporal information should be provided as an interval with start and end timestamps.
+
+NOTE: This Standard only provides guidance how to represent feature data in JSON. It is out-of-scope for this Standard to provide guidance how to cast JSON-FG data to other data types. The Common Query Language (CQL2) standard uses the same model of instants and intervals as JSON-FG and will include additional rules how to cast temporal data types to other temporal data types for the purpose of comparing values. #Add a link to CQL2 once the text is available.#
 
 [#ex-time-1,reftext='{listing-caption} {counter:listing-num}']
 .A date
 ====
 [source,json,linenumbers]
 ----
-"time" : { "instant": "1969-07-20" }
+"time" : { "date": "1969-07-20" }
 ----
 ====
 
@@ -86,7 +91,7 @@ NOTE: #GeoPackage, the next versions of CDB and the Common Query Language will o
 ====
 [source,json,linenumbers]
 ----
-"time" : { "instant": "1969-07-20T20:17:40Z" }
+"time" : { "timestamp": "1969-07-20T20:17:40Z" }
 ----
 ====
 
@@ -94,9 +99,9 @@ This describes the initial range of instant values. This range may be extended i
 
 ==== Intervals
 
-An interval is described by the start and end instants. Both start and end instants are included in the interval.
+An interval is described by start and end instants. Both start and end instants are included in the interval, i.e., the interval is closed.
 
-Unbounded intervals ends are represented by a `null` value for the start/end.
+Unbounded intervals ends are represented by a double-dot string ("..") for the start/end. This follows the convention of ISO 8601-2 for an open start or end.
 
 [#ex-time-3,reftext='{listing-caption} {counter:listing-num}']
 .An interval with dates
@@ -121,13 +126,11 @@ Unbounded intervals ends are represented by a `null` value for the start/end.
 ====
 [source,json,linenumbers]
 ----
-"time" : { "interval": [ "2014-04-24T10:50:18Z", null ] }
+"time" : { "interval": [ "2014-04-24T10:50:18Z", ".." ] }
 ----
 ====
 
 This describes the initial range of interval values. This range may be extended in the future to support additional use cases. Clients processing interval values must be prepared to receive other values. Clients may ignore values that they do not understand.
-
-NOTE: #ISO 8601 also supports intervals by a duration (a start instant and the duration or the duration and an end instant). Should this also be supported or does that make parsing just more complex for clients?#
 
 [[place]]
 === Geometry

--- a/core/clause_7_building_blocks.adoc
+++ b/core/clause_7_building_blocks.adoc
@@ -3,7 +3,7 @@
 
 This chapter describes the JSON building blocks to extend GeoJSON features and feature collections. The following chapters specify the formal requirements classes.
 
-The Annex <<considerations>> contains considerations for each of the JSON-FG building blocks.
+The Annex '<<considerations>>' contains considerations for each of the JSON-FG building blocks.
 
 Known open issues are included in notes with #highlighted# text.
 
@@ -13,28 +13,26 @@ NOTE: #Including information in some kind of 'header' would be helpful. This wou
 
 The following JSON building blocks are specified by this Standard:
 
-* <<when,Encoding the primary temporal geometry>>
-* <<where,Encoding the primary spatial geometry>>
-* <<ref-sys,Encoding of reference systems>>
-* <<feature-types,Identifying the feature type(s)>>
-* <<schema-ref,Identifying the schema(s)>>
+* <<time>>
+* <<place>>
+* <<ref-sys>>
+* <<feature-types>>
+* <<schema-ref>>
 
-An additional topic that was discussed are relationships between a feature and other web resources that are represented as links. This standard does not mandate a specific approach for representing relationships as links. However, Annex <<relationships_and_links>> documents and discusses patterns of how to represent relationships as links.
+An additional topic that was discussed are relationships between a feature and other web resources that are represented as links. This standard does not mandate a specific approach for representing relationships as links. However, Annex '<<relationships_and_links>>' documents and discusses patterns of how to represent relationships as links.
 
-Annex <<examples>> has examples of JSON-FG documents.
+Annex '<<examples>>' has examples of JSON-FG documents.
 
-[[when]]
-=== Encoding the primary temporal geometry
+[[time]]
+=== Temporal information
 
 ==== Overview
 
-Many features have a spatial geometry that provides information about the location of the feature. In GeoJSON, this information is encoded in the "geometry" member. Features often also include temporal information. In most cases this is either an instant (e.g., an event) or an interval (e.g., an activity or a temporal validity). In OGC API Features this is reflected in the http://www.opengis.net/doc/IS/ogcapi-features-1/1.0#_parameter_datetime[parameter "datetime"] for temporal filtering of features that is supported by all compliant APIs.
+Many features have a geometry that provides information about the primary spatial characteristics of the feature. In GeoJSON, this information is encoded in the "geometry" member. Features often also include temporal information. In most cases this is either an instant (e.g., an event) or an interval (e.g., an activity or a temporal validity). In OGC API Features this is reflected in the http://www.opengis.net/doc/IS/ogcapi-features-1/1.0#_parameter_datetime[parameter "datetime"] for temporal filtering of features that is supported by all compliant APIs.
 
 JSON-FG adds support for the most common case: Associating a feature with a single temporal instant or interval in the Gregorian calendar.
 
 More complex cases and other temporal coordinate reference systems are out-of-scope for this Standard and might be specified in future extensions.
-
-NOTE: #There is an existing initiative for a https://github.com/kgeographer/geojson-t[temporal GeoJSON extension ("GeoJSON-T")]. The proposal also uses "when" as a key, but with a different schema for the "when" object. The GeoJSON-T design supports more complex use cases that go beyond the scope of the proposal. To avoid confusion, the SWG should either use a different key than "when" or agree on a joint approach with the GeoJSON-T author (there should be support for simple instants/intervals as a minimal profile, additional capabilities would then extend that minimal profile). The current assumption is we should use a different key to avoid confusion with GeoJSON-T instances.#
 
 ==== Description
 
@@ -43,25 +41,25 @@ Features can have temporal properties. These will typically be included in the "
 * In many datasets all temporal properties are instants (a date or a timestamp) and intervals will be described using two temporal instants, one for the start and one for the end.
 * Multiple temporal properties are sometimes used to describe different temporal characteristics of a feature. For example, the time instant or interval when the information in the feature is valid (sometimes called "valid time") and the time when the feature was recorded in the dataset (sometimes called "transaction time"). Another example is the https://www.ogc.org/standards/om[Observations & Measurements standard], where an observation has multiple temporal properties including "phenomenon time", "result time" and "valid time".
 
-Like GeoJSON, JSON-FG does not place constraints on the information in the "properties" member. JSON-FG specifies a new JSON member in a feature object (key: "when"). The member describes a default temporal geometry (an instant or an interval) that can be used by clients without a need to inspect the "properties" member or to understand the schema of the feature. Clients that are familiar with a dataset can, of course, inspect the information in the "properties" member instead of inspecting the "when" member.
+Like GeoJSON, JSON-FG does not place constraints on the information in the "properties" member. JSON-FG specifies a new JSON member in a feature object (key: "time"). The member describes temporal information (an instant or an interval) that can be used by clients without a need to inspect the "properties" member or to understand the schema of the feature. Clients that are familiar with a dataset can, of course, inspect the information in the "properties" member instead of inspecting the "time" member.
 
-The publisher of the data needs to decide which temporal feature properties are used in the "when" member.
+The publisher of the data needs to decide which temporal feature properties are used in the "time" member.
 
-The value of "when" is either `null` (no primary temporal geometry) or an object.
+The value of "whtimeen" is either `null` (no temporal information) or an object.
 
-.Properties of the "when" object
+.Properties of the "time" object
 [cols="20,10a,70a",options="header"]
 !===
 |Property |Type |Description
-|instant |string |The temporal geometry as an instant. See below for more details about instants.
-|interval |[ string ] |The temporal geometry as an interval, an array of two instants. See below for more details about intervals.
+|instant |string |A timestamp or a date. See below for more details about instants.
+|interval |[ string ] |An interval, described by an array of the two instants (start and end). See below for more details about intervals.
 !===
 
-It is valid to include both an instant and an interval, if both values intersect. Clients should use the interval and may use the instant to determine the temporal geometry of the feature.
+It is valid to include both an instant and an interval, if both values intersect. Clients should use the interval and may use the instant to determine the temporal characteristics of the feature.
 
-The "when" object may be extended with additional members. Clients processing a "when" object must be prepared to parse additional members. Clients should ignore members that they do not understand. For example, in cases where the "when" member neither includes an "instant" or "interval", a client may process the feature as a feature without a temporal geometry.
+The "time" object may be extended with additional members. Clients processing a "time" object must be prepared to parse additional members. Clients should ignore members that they do not understand. For example, in cases where the "time" member neither includes an "instant" or "interval", a client may process the feature as a feature without temporal information.
 
-NOTE: The data publisher decides how temporal properties inside the "properties" member are encoded. The schema for the "when" member does not imply a recommendation that temporal feature properties reuse the same schema. For example, it is expected that a date-valued feature attribute will in most cases be represented as string with an RFC 3339 date value.
+NOTE: The data publisher decides how temporal properties inside the "properties" member are encoded. The schema for the "time" member does not imply a recommendation that temporal feature properties reuse the same schema. For example, it is expected that a date-valued feature attribute will in most cases be represented as string with an RFC 3339 date value.
 
 ==== Instants
 
@@ -74,21 +72,21 @@ Note that all timestamps have to include a time zone. The use of UTC is recommen
 
 NOTE: #GeoPackage, the next versions of CDB and the Common Query Language will only support UTC as a time zone in literal values. Should JSON-FG follow this approach?#
 
-[#ex-when-1,reftext='{listing-caption} {counter:listing-num}']
+[#ex-time-1,reftext='{listing-caption} {counter:listing-num}']
 .A date
 ====
 [source,json,linenumbers]
 ----
-"when" : { "instant": "1969-07-20" }
+"time" : { "instant": "1969-07-20" }
 ----
 ====
 
-[#ex-when-2,reftext='{listing-caption} {counter:listing-num}']
+[#ex-time-2,reftext='{listing-caption} {counter:listing-num}']
 .A timestamp
 ====
 [source,json,linenumbers]
 ----
-"when" : { "instant": "1969-07-20T20:17:40Z" }
+"time" : { "instant": "1969-07-20T20:17:40Z" }
 ----
 ====
 
@@ -100,30 +98,30 @@ An interval is described by the start and end instants. Both start and end insta
 
 Unbounded intervals ends are represented by a `null` value for the start/end.
 
-[#ex-when-3,reftext='{listing-caption} {counter:listing-num}']
+[#ex-time-3,reftext='{listing-caption} {counter:listing-num}']
 .An interval with dates
 ====
 [source,json,linenumbers]
 ----
-"when" : { "interval": [ "1969-07-16", "1969-07-24" ] }
+"time" : { "interval": [ "1969-07-16", "1969-07-24" ] }
 ----
 ====
 
-[#ex-when-4,reftext='{listing-caption} {counter:listing-num}']
+[#ex-time-4,reftext='{listing-caption} {counter:listing-num}']
 .An interval with timestamps
 ====
 [source,json,linenumbers]
 ----
-"when" : { "interval": [ "1969-07-16T05:32:00Z", "1969-07-24T16:50:35Z" ] }
+"time" : { "interval": [ "1969-07-16T05:32:00Z", "1969-07-24T16:50:35Z" ] }
 ----
 ====
 
-[#ex-when-5,reftext='{listing-caption} {counter:listing-num}']
+[#ex-time-5,reftext='{listing-caption} {counter:listing-num}']
 .An half-bounded interval
 ====
 [source,json,linenumbers]
 ----
-"when" : { "interval": [ "2014-04-24T10:50:18Z", null ] }
+"time" : { "interval": [ "2014-04-24T10:50:18Z", null ] }
 ----
 ====
 
@@ -131,35 +129,35 @@ This describes the initial range of interval values. This range may be extended 
 
 NOTE: #ISO 8601 also supports intervals by a duration (a start instant and the duration or the duration and an end instant). Should this also be supported or does that make parsing just more complex for clients?#
 
-[[where]]
-=== Encoding the primary spatial geometry
+[[place]]
+=== Geometry
 
 ==== Overview
 
-Features typically have a spatial geometry that provides information about the location of the feature.
+Features typically have a geometry that provides information about the primary spatial characteristics of the feature.
 
 In GeoJSON, this information is encoded in the "geometry" member. Geometries are according to the Simple Features Standard (2D or 2.5D points, line strings, polygons or aggregations of them) in WGS 84 as the coordinate reference system (OGC:CRS84 or OGC:CRS84h).
 
 A key motivation for JSON-FG is to support additional requirements, especially other coordinate reference systems and solids.
 
-To avoid confusing existing GeoJSON readers, such geometries will be provided in a new member in the feature object with the key "where".
+To avoid confusing existing GeoJSON readers, such geometries will be provided in a new member in the feature object with the key "place".
 
 ==== Description
 
-The primary spatial location of a feature is provided in the "geometry" and/or "where" members of the feature object. The value of both keys is an object representing a spatial geometry - or `null`.
+The primary geometry of a feature is provided in the "geometry" and/or "place" members of the feature object. The value of both keys is an object representing a geometry - or `null`.
 
 The value of the "geometry" member is specified in the GeoJSON standard.
 
-The value range of the "where" member is an extended and extensible version of the value range of the "geometry" member:
+The value range of the "place" member is an extended and extensible version of the value range of the "geometry" member:
 
 * Extended by additional geometry objects (additional JSON-FG geometry types <<Polyhedron>> and <<MultiPolyhedron>>) as well as by the capabilities to <<ref-sys,declare the coordinate reference system of the coordinates>>.
-* Future parts of Features and Geometries JSON or community extensions may specify additional members or additional geometry types. JSON-FG readers should be prepared to parse values of "where" that go beyond the schema that is implemented by the reader. Unknown members should be ignored and geometries that include an unknown geometry type should be mapped to `null`.
+* Future parts of Features and Geometries JSON or community extensions may specify additional members or additional geometry types. JSON-FG readers should be prepared to parse values of "place" that go beyond the schema that is implemented by the reader. Unknown members should be ignored and geometries that include an unknown geometry type should be mapped to `null`.
 
-===== Use of "geometry" and/or "where"
+===== Use of "geometry" and/or "place"
 
-If the primary geometry of the feature can be represented as a valid GeoJSON geometry (one of the GeoJSON geometry types, in WGS84), it is encoded as the value of the "geometry" member. The "where" member has the value `null`.
+If the geometry can be represented as a valid GeoJSON geometry (one of the GeoJSON geometry types, in WGS84), it is encoded as the value of the "geometry" member. The "place" member has the value `null`.
 
-If the geometry cannot be represented as a valid GeoJSON geometry, it is encoded as the value of the "where" member. In addition, a valid GeoJSON geometry may be provided in the "geometry" member in the coordinate reference system WGS84 as specified in the GeoJSON standard (otherwise "geometry" is set to `null`). The geometry in "geometry" is a fallback for readers that support GeoJSON, but not JSON-FG. This could be a simplified geometry, like the building footprint in the <<example_building,example "building with a polyhedron geometry and the polygon footprint">> instead of the solid geometry or the same point/line string/polygon geometry, but in WGS 84 (potentially with fewer vertices to reduce the file size).
+If the geometry cannot be represented as a valid GeoJSON geometry, it is encoded as the value of the "place" member. In addition, a valid GeoJSON geometry may be provided in the "geometry" member in the coordinate reference system WGS84 as specified in the GeoJSON standard (otherwise "geometry" is set to `null`). The geometry in "geometry" is a fallback for readers that support GeoJSON, but not JSON-FG. This could be a simplified geometry, like the building footprint in the <<example_building,example "building with a polyhedron geometry and the polygon footprint">> instead of the solid geometry or the same point/line string/polygon geometry, but in WGS 84 (potentially with fewer vertices to reduce the file size).
 
 The presence of such fallback geometries in a JSON-FG document is indicated by a value "geojson" in the media type parameter "compatibility" (see <<application_fg_json>>).
 
@@ -175,25 +173,37 @@ In other words, every point on a line that does not cross the antimeridian betwe
 
 ===== Polyhedron
 
-A _polyhedron_ is an non-empty array of _multi-polygon_ arrays. Each _multi-polygon_ array is a shell and must be closed. The first shell is the exterior boundary, all other shells are holes.
+A solid is defined by its bounding surfaces. Each bounding surface is a closed, simple surface, also called a shell. 
+
+Each solid has a unique exterior shell and any number of shells that are inside the exterior shell and that describe voids. The interior shells do not intersect each other and cannot contain another interior shell.
+
+A _polyhedron_ is a solid where each shell is a multi-polygon. 'Closed' means that the multi-polygon shell is watertight, it splits space into two distinct regions: inside and outside of the shell. 'Simple' means that the polygons that make up the shell do not intersect, they only touch each other along their common boundaries.
+
+<Add figure(s) illustrating polyhedra.>
+
+The JSON representation of the coordinates of a polyhedron is a non-empty array of _multi-polygon_ arrays. Each _multi-polygon_ array is a shell. The first shell is the exterior boundary, all other shells are voids.
 
 The dimension of all positions is three.
-
-NOTE: #Should a 3D geometry that represents a simple solid constructed using an extruded polygon also be supported? This would consist of a (horizontal) 2D polygon and separate attributes for the lower and upper limits. How often are such geometries used? With respect to "extruded polygons" it seems like they could be useful, but it is unclear if the added complexity of an additional geometry type is valuable enough. This is a broader topic as to how to handle geometries that are constructed using "regular" feature properties.#
 
 ===== MultiPolyhedron
 
 A _multi-polyhedron_ is an array of _polyhedron_ objects. The order of the polyhedron geometry objects in the array is not significant.
 
+===== Prism
+
+NOTE: #Should a 3D geometry that represents a simple solid constructed using an extruded polygon also be supported? This would consist of a (horizontal) 2D polygon and separate attributes for the lower and upper limits. How often are such geometries used? With respect to "extruded polygons" it seems like they could be useful, but it is unclear if the added complexity of an additional geometry type is valuable enough. This is a broader topic as to how to handle geometries that are constructed using "regular" feature properties.#
+
 [[ref-sys]]
-=== Encoding of reference systems
+=== Reference systems
 
 ==== Overview
 
 Without any other information, the following coordinate reference system (CRS) defaults apply in a JSON-FG document:
 
-* spatial CRS: OGC:CRS84 (2D) or OGC:CRS84h (3D)
-* temporal CRS: Proleptic Gregorian calendar using ISO 8601-1 syntax
+* spatial CRS: [OGC:CRS84] (2D) or [OGC:CRS84h] (3D)
+* temporal CRS: A Temporal CRS "DateTime in Gregorian calendar" based on https://docs.ogc.org/as/18-005r4/18-005r4.html#118[OGC Topic 2, Example E.4.1]
+
+NOTE: It is planned to register the Temporal CRS with the OGC Naming Authority and eventually update this document with its URI.
 
 A new key "coordRefSys" is defined and can be used to assert the CRS of a JSON-FG geometry object at the collection, feature or value levels.
 
@@ -205,7 +215,7 @@ Spatio-temporal objects are specified relative to some reference system.
 
 GeoJSON (both the current https://tools.ietf.org/html/rfc7946[RFC] and the https://geojson.org/geojson-spec.html[legacy version]) fixed the reference system for geometric values to the "WGS84 datum, and with longitude and latitude units of decimal degrees".  The https://geojson.org/geojson-spec.html[legacy version] included a "prior arrangement" provision to allow other reference systems to be used and also defined the "crs" key for specifying the reference system.  This _prior arrangement_ mechanism survived into the https://tools.ietf.org/html/rfc7946[RFC] but the accompanying "crs" key did not. The result is that there is no interoperable way to unambiguously specify a different CRS in GeoJSON and the only safe approach is to stick with OGC:CRS84(h) for GeoJSON and ignore the _prior arrangement_ provision and the old "crs" key.
 
-Additional JSON-FG building blocks like the "where" member are not bound by these restrictions and so this Standard provides for handling reference systems in JSON-FG documents that does not interfere with anything, past or present, defined in any of the GeoJSON specifications. The GeoJSON building blocks can continue to operate as always but JSON-FG building blocks can avail themselves of enhanced CRS support.
+Additional JSON-FG building blocks like the "place" member are not bound by these restrictions and so this Standard provides for handling reference systems in JSON-FG documents that does not interfere with anything, past or present, defined in any of the GeoJSON specifications. The GeoJSON building blocks can continue to operate as always but JSON-FG building blocks can avail themselves of enhanced CRS support.
 
 NOTE: #Check original proposal for another alternative how to disambiguate between different JSON objects that represent a CRS by-reference, by-value, etc.#
 
@@ -266,7 +276,7 @@ Used at the geometry level, the "coordRefSys" key asserts the coordinate referen
 Where all objects on the same level are in the same coordinate reference system, it is recommended to declare the coordinate reference system on the parent level instead of declaring it in all parallel objects.
 
 [[feature-types]]
-=== Identifying the feature type(s)
+=== Feature type(s)
 
 ==== Overview
 
@@ -278,7 +288,7 @@ GeoJSON is schema-less in the sense that it has no concept of feature types or f
 
 In most cases, a feature is an instance of a single feature type. The current draft revision of the Simple Features standard supports features that are instances of multiple types. JSON-FG, therefore, also supports multiple feature types.
 
-The related element <<schema-ref,Identifying the schema>> specifies which elements of the JSON Schema documents are identified that the JSON-FG document conforms to. This element specifies how to represent feature type information in the JSON object that represents the feature.
+The related element <<schema-ref>> specifies which elements of the JSON Schema documents are identified that the JSON-FG document conforms to. This element specifies how to represent feature type information in the JSON object that represents the feature.
 
 ==== Description
 
@@ -316,7 +326,7 @@ OGC API Features already specifies a general "links" member with an array of lin
 Additional link attributes may be added to the Link object.
 
 [[schema-ref]]
-=== Identifying the schema(s)
+=== Schema(s)
 
 ==== Overview
 
@@ -379,4 +389,4 @@ NOTE: #Check stability of the GeoJSON URIs with the GeoJSON maintainers.#
 
 NOTE: #JSON Schema is a rich language and it should be considered to limit the language constructs that should be used in describing the properties in the feature schema. A potential starting point is the current proposal for https://docs.ogc.org/DRAFTS/19-079r1.html#rec_filter_queryables-schema[a JSON Schema profile for queryable feature properties].#
 
-NOTE: #The schema of a feature type will typically specify the details of the feature properties, but it can also profile the feature-level members including the "geometry", "where" and "when" members. A typical example is to restrict the list of allowed geometry types. To simplify parsing the feature schemas it could be discussed, if canonical schemas for well-known types should be used in "$ref" members. For example, if the spatial geometry is restricted to points, the "geometry" and "where" members could reference `\https://geojson.org/schema/Point.json` or some other canonical URI.#
+NOTE: #The schema of a feature type will typically specify the details of the feature properties, but it can also profile the feature-level members including the "geometry", "place" and "time" members. A typical example is to restrict the list of allowed geometry types. To simplify parsing the feature schemas it could be discussed, if canonical schemas for well-known types should be used in "$ref" members. For example, if the geometry is restricted to points, the "geometry" and "place" members could reference `\https://geojson.org/schema/Point.json` or some other canonical URI.#

--- a/core/clause_8_core.adoc
+++ b/core/clause_8_core.adoc
@@ -2,7 +2,7 @@
 [#rc_{req-class}]
 == Requirements Class "Core"
 
-The Requirements Class "Core" specifies provisions for encoding information about the primary spatial and temporal geometry of a feature in JSON. 
+The Requirements Class "Core" specifies provisions for encoding information about the primary geometry and temporal information of a feature in JSON. 
 
 [cols="2,7",width="90%"]
 |===
@@ -25,7 +25,7 @@ A JSON-FG document is either a feature or feature collection that meets all requ
 ^|A |The JSON document SHALL validate against <<schema-feature>> (a JSON-FG feature) or <<schema-feature-collection>> (a JSON-FG feature collection).
 |===
 
-=== Encoding the primary temporal geometry
+=== Temporal information
 
 :req: instant
 [#{req-class}_{req}]
@@ -34,7 +34,7 @@ A JSON-FG document is either a feature or feature collection that meets all requ
 [width="90%",cols="2,7a"]
 |===
 ^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
-^|A |If the "when" object in any JSON-FG feature in the JSON document includes an "instant" member, the value SHALL conform to <<rfc3339,RFC 3339 (Date and Time on the Internet: Timestamps)>> and match one of the following production rules: `full-date` (a date) or `date-time` (a timestamp).
+^|A |If the "time" object in any JSON-FG feature in the JSON document includes an "instant" member, the value SHALL conform to <<rfc3339,RFC 3339 (Date and Time on the Internet: Timestamps)>> and match one of the following production rules: `full-date` (a date) or `date-time` (a timestamp).
 |===
 
 :req: interval
@@ -44,7 +44,7 @@ A JSON-FG document is either a feature or feature collection that meets all requ
 [width="90%",cols="2,7a"]
 |===
 ^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
-^|A |If the "when" object in any JSON-FG feature in the JSON document includes an "interval" member, each array item that is a string SHALL conform to <<rfc3339,RFC 3339 (Date and Time on the Internet: Timestamps)>> and match one of the following production rules: `full-date` (a date) or `date-time` (a timestamp).
+^|A |If the "time" object in any JSON-FG feature in the JSON document includes an "interval" member, each array item that is a string SHALL conform to <<rfc3339,RFC 3339 (Date and Time on the Internet: Timestamps)>> and match one of the following production rules: `full-date` (a date) or `date-time` (a timestamp).
 |===
 
 :req: instant-and-interval
@@ -54,7 +54,7 @@ A JSON-FG document is either a feature or feature collection that meets all requ
 [width="90%",cols="2,7a"]
 |===
 ^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
-^|A |If the "when" object in any JSON-FG feature in the JSON document includes both "instant" and "interval" members, the interval SHALL contain the instant.
+^|A |If the "time" object in any JSON-FG feature in the JSON document includes both "instant" and "interval" members, the interval SHALL contain the instant.
 |===
 
 :rec: utc
@@ -64,10 +64,10 @@ A JSON-FG document is either a feature or feature collection that meets all requ
 [width="90%",cols="2,7a"]
 |===
 ^|*Recommendation {counter:rec-num}* |/rec/{req-class}/{rec}
-^|A |Timestamps in the "when" member in any JSON-FG feature in the JSON document SHOULD use UTC ("Z") as the time zone.
+^|A |Timestamps in the "time" member in any JSON-FG feature in the JSON document SHOULD use UTC ("Z") as the time zone.
 |===
 
-=== Encoding the primary spatial geometry
+=== Geometry
 
 :req: coordinate-dimension
 [#{req-class}_{req}]
@@ -76,7 +76,7 @@ A JSON-FG document is either a feature or feature collection that meets all requ
 [width="90%",cols="2,7a"]
 |===
 ^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
-^|A |All positions in a geometry object in the "geometry" or "where" members in any JSON-FG feature in the JSON document SHALL have the same dimension.
+^|A |All positions in a geometry object in the "geometry" or "place" members in any JSON-FG feature in the JSON document SHALL have the same dimension.
 |===
 
 :req: geometry-wgs84
@@ -97,17 +97,17 @@ A JSON-FG document is either a feature or feature collection that meets all requ
 [width="90%",cols="2,7a"]
 |===
 ^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
-^|A |If the "where" member in any JSON-FG feature in the JSON document is not `null` and the geometry type (member "type") is one of "Point", "MultiPoint", "LineString", "MultiLineString", "Polygon" or "MultiPolygon", the geometry objects SHALL be valid geometries according to <<ogc06_103r4,Simple feature access - Part 1: Common architecture>>.
+^|A |If the "place" member in any JSON-FG feature in the JSON document is not `null` and the geometry type (member "type") is one of "Point", "MultiPoint", "LineString", "MultiLineString", "Polygon" or "MultiPolygon", the geometry objects SHALL be valid geometries according to <<ogc06_103r4,Simple feature access - Part 1: Common architecture>>.
 |===
 
-:req: where
+:req: place
 [#{req-class}_{req}]
-==== No GeoJSON geometry in "where"
+==== No GeoJSON geometry in "place"
 
 [width="90%",cols="2,7a"]
 |===
 ^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
-^|A |If the "where" member in any JSON-FG feature in the JSON document is not `null` and the geometry type (member "type") is one of "Point", "MultiPoint", "LineString", "MultiLineString", "Polygon" or "MultiPolygon", the CRS SHALL not use WGS84 longitude/latitude as the first two coordinate axes.
+^|A |If the "place" member in any JSON-FG feature in the JSON document is not `null` and the geometry type (member "type") is one of "Point", "MultiPoint", "LineString", "MultiLineString", "Polygon" or "MultiPolygon", the CRS SHALL not use WGS84 longitude/latitude as the first two coordinate axes.
 |===
 
 The coordinate reference system of a geometry object is determined as follows: 
@@ -124,18 +124,18 @@ The coordinate reference system of a geometry object is determined as follows:
 [width="90%",cols="2,7a"]
 |===
 ^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
-^|A |If both the "where" and the "geometry" member in a JSON-FG feature in the JSON document are not `null`, the values SHALL not be identical.
-^|B |If both the "where" and the "geometry" member in a JSON-FG feature in the JSON document are not `null` and the JSON document is associated with a media type (e.g., the JSON document is fetched with a HTTP request), the media type SHALL include a parameter "compatibility" with a value "geojson".
+^|A |If both the "place" and the "geometry" member in a JSON-FG feature in the JSON document are not `null`, the values SHALL not be identical.
+^|B |If both the "place" and the "geometry" member in a JSON-FG feature in the JSON document are not `null` and the JSON document is associated with a media type (e.g., the JSON document is fetched with a HTTP request), the media type SHALL include a parameter "compatibility" with a value "geojson".
 |===
 
-:rec: where-crs
+:rec: place-crs
 [#{req-class}_{rec}]
-==== Coordinate values in "where"
+==== Coordinate values in "place"
 
 [width="90%",cols="2,7a"]
 |===
 ^|*Recommendation {counter:rec-num}* |/rec/{req-class}/{rec}
-^|A |If the "where" member in any JSON-FG feature in the JSON document is not `null`, the first element of each position SHOULD be in the valid range for the first coordinate axis of the CRS.
+^|A |If the "place" member in any JSON-FG feature in the JSON document is not `null`, the first element of each position SHOULD be in the valid range for the first coordinate axis of the CRS.
 ^|B |If the "geometry" member in any JSON-FG feature in the JSON document is not `null`, the second element of each position SHOULD be in the valid range for the second coordinate axis of the CRS.
 |===
 

--- a/core/clause_8_core.adoc
+++ b/core/clause_8_core.adoc
@@ -34,7 +34,8 @@ A JSON-FG document is either a feature or feature collection that meets all requ
 [width="90%",cols="2,7a"]
 |===
 ^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
-^|A |If the "time" object in any JSON-FG feature in the JSON document includes an "instant" member, the value SHALL conform to <<rfc3339,RFC 3339 (Date and Time on the Internet: Timestamps)>> and match one of the following production rules: `full-date` (a date) or `date-time` (a timestamp).
+^|A |If the "time" object in any JSON-FG feature in the JSON document includes an "date" member, the value SHALL conform to <<rfc3339,RFC 3339 (Date and Time on the Internet: Timestamps)>> and match the production rule `full-date`.
+^|B |If the "time" object in any JSON-FG feature in the JSON document includes an "timestamp" member, the value SHALL conform to <<rfc3339,RFC 3339 (Date and Time on the Internet: Timestamps)>> and match the production rule `date-time`.
 |===
 
 :req: interval
@@ -44,7 +45,9 @@ A JSON-FG document is either a feature or feature collection that meets all requ
 [width="90%",cols="2,7a"]
 |===
 ^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
-^|A |If the "time" object in any JSON-FG feature in the JSON document includes an "interval" member, each array item that is a string SHALL conform to <<rfc3339,RFC 3339 (Date and Time on the Internet: Timestamps)>> and match one of the following production rules: `full-date` (a date) or `date-time` (a timestamp).
+^|A |If the "time" object in any JSON-FG feature in the JSON document includes an "interval" member, each array item SHALL be a string that is a double-dot ("..") or conforms to <<rfc3339,RFC 3339 (Date and Time on the Internet: Timestamps)>> and match one of the following production rules: `full-date` (a date) or `date-time` (a timestamp).
+^|B |If the start is a date, the end SHALL be a date, too, or "..".
+^|C |If the start is a timestamp, the end SHALL be a timestamp, too, or "..".
 |===
 
 :req: instant-and-interval
@@ -54,17 +57,21 @@ A JSON-FG document is either a feature or feature collection that meets all requ
 [width="90%",cols="2,7a"]
 |===
 ^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
-^|A |If the "time" object in any JSON-FG feature in the JSON document includes both "instant" and "interval" members, the interval SHALL contain the instant.
+^|A |If the "time" object in any JSON-FG feature in the JSON document includes both a "date" and a "timestamp" member, the `full-date` parts SHALL be identical.
+^|B |If the "time" object in any JSON-FG feature in the JSON document includes both a "timestamp" and an "interval" member with start/end dates, the interval SHALL contain the date of the timestamp.
+^|C |If the "time" object in any JSON-FG feature in the JSON document includes both a "timestamp" and an "interval" member with start/end timestamps, the interval SHALL contain the timestamp.
+^|D |If the "time" object in any JSON-FG feature in the JSON document includes both a "date" and an "interval" member with with start/end dates, the interval SHALL contain the date.
+^|E |If the "time" object in any JSON-FG feature in the JSON document includes both a "date" and an "interval" member with with start/end timestamps, the interval SHALL include timestamps on the date.
 |===
 
-:rec: utc
-[#{req-class}_{rec}]
+:req: utc
+[#{req-class}_{req}]
 ==== Time zones
 
 [width="90%",cols="2,7a"]
 |===
-^|*Recommendation {counter:rec-num}* |/rec/{req-class}/{rec}
-^|A |Timestamps in the "time" member in any JSON-FG feature in the JSON document SHOULD use UTC ("Z") as the time zone.
+^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
+^|A |Timestamps in the "time" member in any JSON-FG feature in the JSON document SHALL use UTC ("Z") as the time zone.
 |===
 
 === Geometry

--- a/core/clause_9_3d.adoc
+++ b/core/clause_9_3d.adoc
@@ -11,7 +11,7 @@ The Requirements Class "3D" add provisions for geometries in a 3D CRS and that m
 |Dependency |<<rc_core>>
 |===
 
-=== Encoding the primary spatial geometry
+=== Geometry
 
 :req: coordinate-dimension
 [#{req-class}_{req}]
@@ -20,7 +20,7 @@ The Requirements Class "3D" add provisions for geometries in a 3D CRS and that m
 [width="90%",cols="2,7a"]
 |===
 ^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
-^|A |All positions in a geometry object in the "where" member in any JSON-FG feature in the JSON document SHALL have coordinate dimension 3.
+^|A |All positions in a geometry object in the "place" member in any JSON-FG feature in the JSON document SHALL have coordinate dimension 3.
 |===
 
 :req: geom-valid
@@ -30,5 +30,5 @@ The Requirements Class "3D" add provisions for geometries in a 3D CRS and that m
 [width="90%",cols="2,7a"]
 |===
 ^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
-^|A |If the "where" member in any JSON-FG feature in the JSON document is not `null` and the geometry type (member "type") is one of "Polyhedron" or "MultiPolyhedron", the geometry objects SHALL be valid geometries according to #TODO#.
+^|A |If the "place" member in any JSON-FG feature in the JSON document is not `null` and the geometry type (member "type") is one of "Polyhedron" or "MultiPolyhedron", the geometry objects SHALL be valid geometries according to #TODO#.
 |===

--- a/core/examples/feature.json
+++ b/core/examples/feature.json
@@ -2,11 +2,11 @@
    "type": "Feature",
    "id": "DENW19AL0000giv5BL",
    "featureType": "app:building",
-   "when": {
+   "time": {
       "interval": [ "2014-04-24T10:50:18Z", null ]
    },
    "coordRefSys": "http://www.opengis.net/def/crs/EPSG/0/5555",
-   "where": {
+   "place": {
       "type": "Polyhedron",
       "coordinates": [
          [

--- a/core/schemas/feature.json
+++ b/core/schemas/feature.json
@@ -3,7 +3,7 @@
   "$id": "http://beta.schemas.opengis.net/json-fg/feature.json",
   "title": "a JSON-FG Feature",
   "type": "object",
-  "required": ["type", "when", "where", "geometry", "properties"],
+  "required": ["type", "time", "place", "geometry", "properties"],
   "properties": {
     "type": {
       "type": "string",
@@ -28,14 +28,14 @@
         "$ref": "link.json"
       }
     },
-    "when": {
-      "$ref": "when.json"
+    "time": {
+      "$ref": "time.json"
     },
     "coordRefSys": {
       "$ref": "coordrefsys.json"
     },
-    "where": {
-      "$ref": "where.json"
+    "place": {
+      "$ref": "place.json"
     },
     "geometry": {
       "$ref": "geometry.json"

--- a/core/schemas/place.json
+++ b/core/schemas/place.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "http://beta.schemas.opengis.net/json-fg/where.json",
-  "title": "where",
+  "$id": "http://beta.schemas.opengis.net/json-fg/place.json",
+  "title": "place",
   "oneOf": [
     {
       "type": "null"

--- a/core/schemas/time.json
+++ b/core/schemas/time.json
@@ -9,8 +9,11 @@
     {
       "type": "object",
       "properties": {
-        "instant": {
-          "$ref": "#/$defs/instant"
+        "date": {
+          "$ref": "#/$defs/date"
+        },
+        "timestamp": {
+          "$ref": "#/$defs/timestamp"
         },
         "interval": {
           "$ref": "#/$defs/interval"
@@ -19,8 +22,13 @@
     }
   ],
   "$defs": {
-    "instant": {
-      "type": "string"
+    "date": {
+      "type": "string",
+      "format": "date"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
     },
     "interval": {
       "type": "array",
@@ -29,10 +37,14 @@
       "items": {
         "oneOf": [
           {
-            "$ref": "#/$defs/instant"
+            "$ref": "#/$defs/date"
           },
           {
-            "type": "null"
+            "$ref": "#/$defs/timestamp"
+          },
+          {
+            "type": "string",
+            "enum": [ ".." ]
           }
         ]
       }

--- a/core/schemas/time.json
+++ b/core/schemas/time.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "http://beta.schemas.opengis.net/json-fg/when.json",
-  "title": "when",
+  "$id": "http://beta.schemas.opengis.net/json-fg/time.json",
+  "title": "time",
   "oneOf": [
     {
       "type": "null"


### PR DESCRIPTION
This update addresses the following issues in addition to some editorial updates:

* #23: "when" has changed to "time", "where" to "place"
* #31: "temporal geometry" is no longer used and "geometry" always means spatial geometry
* #34: The Temporal CRS description has been updated
* #37: The text about polyhedra has been updated (it would be good to also add some figures)
* #38: definitions for "primary geometry" and "primary temporal information" have been added with explanatory notes; I have also added definitions for "member" and "key" as these terms are also commonly used in the context of JSON

@pvretano - Please review. I would say that if this looks good, feel free to merge so that the HTML is updated and we avoid conflicts with your planned edits. We keep the issues open until we have confirmed that the edits resolve the issues.