### PR TITLE
Initial cut at clarifying that axis order for JSON-FG geometry object is

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ JSON is a popular encoding format for geospatial data. The light weight, simple 
 OGC Features and Geometries JSON will
 
 * include the ability to use Coordinate Reference Systems (CRSs) other than WGS84 
-* follow the https://portal.opengeospatial.org/files/?artifact_id=76024[OGC Axis Order Policy] when CRSs other than WGS84 are used,
+* follow the https://portal.opengeospatial.org/files/?artifact_id=76024[OGC Axis Order Policy],
 * allow the use of non-Euclidean metrics, in particular ellipsoidal metrics,
 * support solids and multi-solids as geometry types, and
 * provide guidance on how to represent feature properties, e.g., including temporal properties.

--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ JSON is a popular encoding format for geospatial data. The light weight, simple 
 
 OGC Features and Geometries JSON will
 
-* include the ability to use Coordinate Reference Systems (CRSs) other than WGS84,
+* include the ability to use Coordinate Reference Systems (CRSs) other than WGS84 
+* follow the https://portal.opengeospatial.org/files/?artifact_id=76024[OGC Axis Order Policy] when CRSs other than WGS84 are used,
 * allow the use of non-Euclidean metrics, in particular ellipsoidal metrics,
 * support solids and multi-solids as geometry types, and
 * provide guidance on how to represent feature properties, e.g., including temporal properties.
+
 
 These capabilities will be supported by Part 1 (Core) or the OGC Features and Geometries JSON standard.
 

--- a/core/clause_7_building_blocks.adoc
+++ b/core/clause_7_building_blocks.adoc
@@ -278,6 +278,10 @@ Used at the geometry level, the "coordRefSys" key asserts the coordinate referen
 
 Where all objects on the same level are in the same coordinate reference system, it is recommended to declare the coordinate reference system on the parent level instead of declaring it in all parallel objects.
 
+===== Coordinate order
+
+The order in which coordinates for JSON-FG geometry objects are expressed is defined in the https://portal.opengeospatial.org/files/?artifact_id=76024[OGC Axis Order Policy] and shall be in the axis order defined by the closest-to-scope CRS metadata.
+
 [[feature-types]]
 === Feature type(s)
 

--- a/core/clause_8_core.adoc
+++ b/core/clause_8_core.adoc
@@ -135,6 +135,17 @@ The coordinate reference system of a geometry object is determined as follows:
 ^|B |If both the "place" and the "geometry" member in a JSON-FG feature in the JSON document are not `null` and the JSON document is associated with a media type (e.g., the JSON document is fetched with a HTTP request), the media type SHALL include a parameter "compatibility" with a value "geojson".
 |===
 
+:rec: axis-order
+[#{req-class}_{rec}]
+==== Axis order of coordinate values in "place"
+
+[width="90%",cols="2,7a"]
+|===
+^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
+
+If the "place" member in any JSON-FG feature in the JSON document is not `null`, the coordinates of each position SHALL be expressed according to the https://portal.opengeospatial.org/files/?artifact_id=76024[OGC Axis Order Policy] and SHALL be in the axis order defined by the closest-to-scope CRS metadata.
+|===
+
 :rec: place-crs
 [#{req-class}_{rec}]
 ==== Coordinate values in "place"


### PR DESCRIPTION
as defined in the OGC Axis Order policy (i.e. using the axis order
defined in the closest-to-scope CRS metadata).