### PR TITLE
clarifications on GeometryCollection

### DIFF
--- a/core/clause_7_building_blocks.adoc
+++ b/core/clause_7_building_blocks.adoc
@@ -158,6 +158,8 @@ The value range of the "place" member is an extended and extensible version of t
 
 All coordinates in a "place" member are in the same coordinate reference system. This includes GeometryCollection geometries, where all geometries have to be in the same coordinate reference system.
 
+NOTE: This standard does not add a new JSON-FG geometry collection that also includes the new geometry types introduced by JSON-FG, because geometry collections are rarely used as feature geometries.
+
 ===== Use of "geometry" and/or "place"
 
 If the geometry can be represented as a valid GeoJSON geometry (one of the GeoJSON geometry types, in WGS84), it is encoded as the value of the "geometry" member. The "place" member then has the value `null`.

--- a/core/clause_7_building_blocks.adoc
+++ b/core/clause_7_building_blocks.adoc
@@ -156,6 +156,8 @@ The value range of the "place" member is an extended and extensible version of t
 * Extended by additional geometry objects (additional JSON-FG geometry types <<Polyhedron>>, <<MultiPolyhedron>>, <<Prism>>, and <<MultiPrism>>) as well as by the capabilities to <<ref-sys,declare the coordinate reference system of the coordinates>>.
 * Future parts of Features and Geometries JSON or community extensions may specify additional members or additional geometry types. JSON-FG readers should be prepared to parse values of "place" that go beyond the schema that is implemented by the reader. Unknown members should be ignored and geometries that include an unknown geometry type should be mapped to `null`.
 
+All coordinates in a "place" member are in the same coordinate reference system. This includes GeometryCollection geometries, where all geometries have to be in the same coordinate reference system.
+
 ===== Use of "geometry" and/or "place"
 
 If the geometry can be represented as a valid GeoJSON geometry (one of the GeoJSON geometry types, in WGS84), it is encoded as the value of the "geometry" member. The "place" member then has the value `null`.
@@ -333,7 +335,7 @@ Used at the feature collection level, the "coordRefSys" key asserts the CRS for 
 
 Used at the feature level, the "coordRefSys" key asserts the CRS for JSON-FG geometry objects found anywhere in the feature that are not otherwise tagged with closer-to-scope CRS information.
 
-Used at the geometry level, the "coordRefSys" key asserts the CRS for the JSON-FG geometry object within which the key is contained.
+Used at the geometry level, the "coordRefSys" key asserts the CRS for the JSON-FG geometry object within which the key is contained. For a GeometryCollection, all geometries in the collection have to be in the same CRS (this constraint is "inherited" from the <<ogc06_103r4,OGC Simple Feature Access standard>>) and cannot include a "coordRefSys" member.
 
 Where all objects on the same level are in the same CRS, declaring the CRS on the parent level instead of declaring it in all parallel objects is recommended.
 

--- a/core/clause_8_core.adoc
+++ b/core/clause_8_core.adoc
@@ -106,7 +106,7 @@ While every JSON-FG document has to validate against the associated JSON-FG sche
 [width="90%",cols="2,7a"]
 |===
 ^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
-^|A |If the "place" member in any JSON-FG feature in the JSON document is not `null` and the geometry type (member "type") is one of "Point", "MultiPoint", "LineString", "MultiLineString", "Polygon" or "MultiPolygon", the geometry objects SHALL be valid geometries according to <<ogc06_103r4,Simple feature access - Part 1: Common architecture>>.
+^|A |If the "place" member in any JSON-FG feature in the JSON document is not `null` and the geometry type (member "type") is one of "Point", "MultiPoint", "LineString", "MultiLineString", "Polygon",  "MultiPolygon" or "GeometryCollection", the geometry objects SHALL be valid geometries according to <<ogc06_103r4,Simple feature access - Part 1: Common architecture>>.
 |===
 
 :req: place
@@ -116,7 +116,7 @@ While every JSON-FG document has to validate against the associated JSON-FG sche
 [width="90%",cols="2,7a"]
 |===
 ^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
-^|A |If the "place" member in any JSON-FG feature in the JSON document is not `null` and the geometry type (member "type") is one of "Point", "MultiPoint", "LineString", "MultiLineString", "Polygon" or "MultiPolygon", the CRS SHALL not be `OGC:CRS84` or `OGC:CRS84h` (WGS 84 with axis order longitude/latitude).
+^|A |If the "place" member in any JSON-FG feature in the JSON document is not `null` and the geometry type (member "type") is one of "Point", "MultiPoint", "LineString", "MultiLineString", "Polygon", "MultiPolygon" or "GeometryCollection", the CRS SHALL not be `OGC:CRS84` or `OGC:CRS84h` (WGS 84 with axis order longitude/latitude).
 |===
 
 The CRS of a geometry object is determined as follows: 
@@ -125,6 +125,16 @@ The CRS of a geometry object is determined as follows:
 ** Otherwise inspect the parent object and repeat until the root object.
 * If no "coordRefSys" member has been found, the CRS has WGS84 longitude/latitude as the first two coordinate axes (that is, the requirement above is not met).
 * Otherwise inspect the CRS URI, CRS CURIE or CRS object to determine the datum and the first two coordinate axes.
+
+:req: geometry-collection
+[#{req-class}_{req}]
+==== All coordinates in a geometry collection are in the same CRS
+
+[width="90%",cols="2,7a"]
+|===
+^|*Requirement {counter:req-num}* |/req/{req-class}/{req}
+^|A |If the "place" member in any JSON-FG feature in the JSON document is not `null` and the geometry type (member "type") is "GeometryCollection", no geometry in the collection SHALL include a "coordRefSys" member.
+|===
 
 :req: fallback
 [#{req-class}_{req}]


### PR DESCRIPTION
All geometries in a GeometryCollection must be in the same CRS. This addresses part of #71.

Open topic: should there also be a JSON-FG GeometryCollection that includes additional JSON-FG geometry types? I will make this a draft PR until this is resolved.